### PR TITLE
Allow more ajv options

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ const api = new Api({
   controllers,
   secret: 'test',
   logger: console,
-  allErrors: true
+  ajvOptions: { allErrors: true }
 })
 const { app } = await setupServer({
   env: process.env,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@trojs/openapi-server",
-    "version": "1.0.6",
+    "version": "1.0.7",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@trojs/openapi-server",
-            "version": "1.0.6",
+            "version": "1.0.7",
             "license": "MIT",
             "dependencies": {
                 "@sentry/node": "^7.112.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@trojs/openapi-server",
     "description": "OpenAPI Server",
-    "version": "1.0.6",
+    "version": "1.0.7",
     "author": {
         "name": "Pieter Wigboldus",
         "url": "https://trojs.org/"

--- a/src/api.js
+++ b/src/api.js
@@ -25,7 +25,7 @@ import { setupRouter } from './router.js'
  * @property {SecurityHandler[]=} securityHandlers
  * @property {boolean=} swagger
  * @property {boolean=} apiDocs
- * @property {boolean=} allErrors
+ * @property {object=} ajvOptions
  */
 
 /**
@@ -36,7 +36,7 @@ export class Api {
   /**
    * @param {ApiSchema} params
    */
-  constructor ({ version, specification, controllers, secret, apiRoot, strictSpecification, errorDetails, logger, meta, securityHandlers, swagger, apiDocs, allErrors }) {
+  constructor ({ version, specification, controllers, secret, apiRoot, strictSpecification, errorDetails, logger, meta, securityHandlers, swagger, apiDocs, ajvOptions }) {
     this.version = version
     this.specification = specification
     this.controllers = controllers
@@ -49,7 +49,7 @@ export class Api {
     this.securityHandlers = securityHandlers || []
     this.swagger = swagger ?? true
     this.apiDocs = apiDocs ?? true
-    this.allErrors = allErrors ?? false
+    this.ajvOptions = ajvOptions ?? { allErrors: false }
   }
 
   setup () {
@@ -74,7 +74,7 @@ export class Api {
       logger: this.logger,
       meta: this.meta,
       securityHandlers: this.securityHandlers,
-      allErrors: this.allErrors
+      ajvOptions: this.ajvOptions
     })
     api.init()
 

--- a/src/router.js
+++ b/src/router.js
@@ -21,15 +21,15 @@ import { unauthorized } from './handlers/unauthorized.js'
  * @param {Logger=} params.logger
  * @param {object=} params.meta
  * @param {SecurityHandler[]=} params.securityHandlers
- * @param {boolean=} params.allErrors
+ * @param {object=} params.ajvOptions
  * @returns {{ api, openAPISpecification: object }}
  */
-export const setupRouter = ({ secret, openAPISpecification, controllers, apiRoot, strictSpecification, errorDetails, logger, meta, securityHandlers = [], allErrors = false }) => {
+export const setupRouter = ({ secret, openAPISpecification, controllers, apiRoot, strictSpecification, errorDetails, logger, meta, securityHandlers = [], ajvOptions = {} }) => {
   const api = new OpenAPIBackend({
     definition: openAPISpecification,
     apiRoot,
     strict: strictSpecification,
-    ajvOpts: { allErrors },
+    ajvOpts: ajvOptions,
     customizeAjv: (originalAjv) => {
       addFormats(originalAjv)
       return originalAjv

--- a/src/server.test.js
+++ b/src/server.test.js
@@ -63,7 +63,7 @@ const api = new Api({
   controllers,
   secret: envExample.SECRET,
   securityHandlers,
-  allErrors: true
+  ajvOptions: { allErrors: true }
 })
 const { app } = await setupServer({
   env: envExample,


### PR DESCRIPTION
Add ajv option allErrors, see https://ajv.js.org/options.html#allerrors

```javascript
const api = new OpenAPIBackend({
    definition: openAPISpecification,
    strict: true,
    ajvOpts: { allErrors: true },
    customizeAjv: (originalAjv) => {
      addFormats(originalAjv)
      return originalAjv
    }
})
```

You can do now:
```javascript
new Api({
    specification: openAPISpecification,
    controllers: controllers,
    ajvOptions: { allErrors: true }
})
```