### PR TITLE
Add generic option to controller typedef

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -29,16 +29,23 @@ const getOriginResourcePolicy = (origin) => ({
  * @typedef {import('./api.js').ApiSchema} ApiSchema
  * @typedef {import('./api.js').Logger} Logger
  * @typedef {import('express').Express} Express
+ */
+
+/**
+ * @template {object} [T=object]
  * @typedef {object} Controller
  * @property {Context=} context
  * @property {Request=} request
  * @property {Response=} response
  * @property {object=} parameters
  * @property {object=} specification
- * @property {object=} post
+ * @property {T=} post
  * @property {string=} url
  * @property {Logger=} logger
  * @property {object=} meta
+ */
+
+/**
  * @typedef {object} SentryConfig
  * @property {string=} dsn
  * @property {number=} tracesSampleRate


### PR DESCRIPTION
## What

Adds generic option to Controller typedef

```
/**
 * @async
 * @param {Controller<SentryConfig>} params
 * @returns {Promise<SentryConfig['dsn']>}
 */
const getDsnExampleFunction = async ({ context, response, post }) => post.dsn // has autocomplete now if you pass in a generic: Controller<SentryConfig>
```


Without an option to not use an generic type still works, object is the fallback:

```
/**
 * @async
 * @param {Controller} params
 * @returns {Promise<string>}
 */
const getDsnExampleFunction = async ({ context, response, post }) => post.dsn // this is type as any like before
```

