### PR TITLE
Remove Node 19 and 21 from supported node versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 21.x, 22.x]
+        node-version: [18.x, 20.x, 22.x]
 
     steps:
       - uses: actions/checkout@v4

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
                 "supertest": "^7.0.0"
             },
             "engines": {
-                "node": ">= 18.13"
+                "node": ">= 18.13 < 19 || >= 20 < 21 || >= 22 < 23"
             },
             "funding": {
                 "type": "github",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
         "url": "https://github.com/trojs/openapi-server"
     },
     "engines": {
-        "node": ">= 18.13"
+        "node": ">= 18.13 < 19 || >= 20 < 21 || >= 22 < 23"
     },
     "keywords": [
         "openapi",


### PR DESCRIPTION
### What

Removes currently supported node versions that became unsupported: https://endoflife.date/nodejs.