### PR TITLE
Add option to customize the ajv validator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@trojs/openapi-server",
-    "version": "3.0.0",
+    "version": "3.1.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@trojs/openapi-server",
-            "version": "3.0.0",
+            "version": "3.1.0",
             "license": "MIT",
             "dependencies": {
                 "@sentry/node": "^8.0.0",
@@ -3655,6 +3655,16 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/async-function": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
+            "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/asynckit": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -4505,9 +4515,9 @@
             "license": "MIT"
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.84",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.84.tgz",
-            "integrity": "sha512-I+DQ8xgafao9Ha6y0qjHHvpZ9OfyA1qKlkHkjywxzniORU2awxyz7f/iVJcULmrF2yrM3nHQf+iDjJtbbexd/g==",
+            "version": "1.5.87",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.87.tgz",
+            "integrity": "sha512-mPFwmEWmRivw2F8x3w3l2m6htAUN97Gy0kwpO++2m9iT1Gt8RCFVUfv9U/sIbHJ6rY4P6/ooqFL/eL7ock+pPg==",
             "dev": true,
             "license": "ISC"
         },
@@ -6167,12 +6177,13 @@
             }
         },
         "node_modules/is-async-function": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.0.tgz",
-            "integrity": "sha512-GExz9MtyhlZyXYLxzlJRj5WUCE661zhDa1Yna52CN57AJsymh+DvXXjyveSioqSRdxvUrdKdvqB1b5cVKsNpWQ==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
+            "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
+                "async-function": "^1.0.0",
                 "call-bound": "^1.0.3",
                 "get-proto": "^1.0.1",
                 "has-tostringtag": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@trojs/openapi-server",
     "description": "OpenAPI Server",
-    "version": "3.0.0",
+    "version": "3.1.0",
     "author": {
         "name": "Pieter Wigboldus",
         "url": "https://trojs.org/"
@@ -80,7 +80,7 @@
         "url": "https://github.com/sponsors/w3nl"
     },
     "overrides": {
-        "semver": "^7.5.3",
+        "semver@<=7.5.3": "^7.5.3",
         "send@<=0.19.0": "^0.19.0",
         "cookie@<=0.7.0": "0.7.0"
     }

--- a/src/router.js
+++ b/src/router.js
@@ -11,6 +11,7 @@ import { unauthorized } from './handlers/unauthorized.js'
  * @typedef {import('./api.js').Logger} Logger
  * @typedef {import('./api.js').SecurityHandler} SecurityHandler
  * @typedef {import('ajv').Options} AjvOpts
+ * @typedef {import('openapi-backend').AjvCustomizer} AjvCustomizer
  */
 
 /**
@@ -25,6 +26,7 @@ import { unauthorized } from './handlers/unauthorized.js'
  * @param {object=} params.meta
  * @param {SecurityHandler[]=} params.securityHandlers
  * @param {AjvOpts=} params.ajvOptions
+ * @param {AjvCustomizer=} params.customizeAjv
  * @param {boolean=} params.mock
  * @returns {{ api: OpenAPIBackend<any>, openAPISpecification: object }}
  */
@@ -38,17 +40,19 @@ export const setupRouter = ({
     meta,
     securityHandlers = [],
     ajvOptions = {},
+    customizeAjv,
     mock
 }) => {
+    const ajvWithExtraFormats = (originalAjv) => {
+        addFormats(originalAjv)
+        return originalAjv
+    }
     const api = new OpenAPIBackend({
         definition: openAPISpecification,
         apiRoot,
         strict: strictSpecification,
         ajvOpts: ajvOptions,
-        customizeAjv: (originalAjv) => {
-            addFormats(originalAjv)
-            return originalAjv
-        }
+        customizeAjv: customizeAjv || ajvWithExtraFormats
     })
 
     api.register({

--- a/src/router.test.js
+++ b/src/router.test.js
@@ -40,7 +40,14 @@ test('Test the router', async (t) => {
             const { api } = setupRouter({
                 secret: envExample.SECRET,
                 openAPISpecification,
-                controllers
+                controllers,
+                customizeAjv: (originalAjv) => {
+                    originalAjv.addKeyword('example', {
+                        validate: (schema, data) => data === 'example',
+                        errors: false
+                    })
+                    return originalAjv
+                }
             })
             const context = {
                 response: {


### PR DESCRIPTION
Closes: #263

```javascript
import Ajv from 'ajv'
import addFormats from 'ajv-formats'
import addKeywords from 'ajv-keywords'

// Custom function to customize Ajv instance
const customizeAjv = (ajv) => {
  // Add custom formats
  addFormats(ajv)
  
  // Add custom keywords
  addKeywords(ajv, ['transform', 'uniqueItemProperties'])

  // Add custom validation rules or plugins
  ajv.addKeyword('example', {
    validate: (schema, data) => true, // Example custom validation
    errors: false
  })

  return ajv
}

setupRouter({
    ...
    customizeAjv
})
    
    ```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced router configuration with optional AJV (JSON schema validation) customization.
  - Added flexibility for custom validation logic in router setup.

- **Improvements**
  - Centralized AJV configuration mechanism.
  - Improved type annotations for router setup function.

- **Chores**
  - Updated package version from 3.0.0 to 3.1.0.
  - Modified dependency constraints for "semver". 

- **Tests**
  - Updated test cases to support new router configuration options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->