### PR TITLE
Return the status of the error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
             },
             "devDependencies": {
                 "@eslint/js": "^9.15.0",
+                "@trojs/error": "^4.3.6",
                 "@trojs/lint": "^0.3.4",
                 "@types/express-serve-static-core": "^5.0.6",
                 "@types/node": "^22.0.0",
@@ -76,13 +77,13 @@
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.28.0",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.0.tgz",
-            "integrity": "sha512-jVZGvOxOuNSsuQuLRTh13nU0AogFlw32w/MT+LV6D3sP5WdbW61E77RnkbaO2dUvmPAYrBDJXGn5gGS6tH4j8g==",
+            "version": "7.28.4",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.4.tgz",
+            "integrity": "sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.28.0"
+                "@babel/types": "^7.28.4"
             },
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -92,9 +93,9 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.28.2",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.2.tgz",
-            "integrity": "sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==",
+            "version": "7.28.4",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz",
+            "integrity": "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -117,21 +118,21 @@
             }
         },
         "node_modules/@emnapi/core": {
-            "version": "1.4.5",
-            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.4.5.tgz",
-            "integrity": "sha512-XsLw1dEOpkSX/WucdqUhPWP7hDxSvZiY+fsUC14h+FtQ2Ifni4znbBt8punRX+Uj2JG/uDb8nEHVKvrVlvdZ5Q==",
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.5.0.tgz",
+            "integrity": "sha512-sbP8GzB1WDzacS8fgNPpHlp6C9VZe+SJP3F90W9rLemaQj2PzIuTEl1qDOYQf58YIpyjViI24y9aPWCjEzY2cg==",
             "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@emnapi/wasi-threads": "1.0.4",
+                "@emnapi/wasi-threads": "1.1.0",
                 "tslib": "^2.4.0"
             }
         },
         "node_modules/@emnapi/runtime": {
-            "version": "1.4.5",
-            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.4.5.tgz",
-            "integrity": "sha512-++LApOtY0pEEz1zrd9vy1/zXVaVJJ/EbAF3u0fXIzPJEDtnITsBGbbK0EkM72amhl/R5b+5xx0Y/QhcVOpuulg==",
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.5.0.tgz",
+            "integrity": "sha512-97/BJ3iXHww3djw6hYIfErCZFee7qCtrneuLa20UXFCOTCfBM2cvQHjWJ2EG0s0MtdNwInarqCTz35i4wWXHsQ==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -140,9 +141,9 @@
             }
         },
         "node_modules/@emnapi/wasi-threads": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.0.4.tgz",
-            "integrity": "sha512-PJR+bOmMOPH8AtcTGAyYNiuJ3/Fcoj2XN/gBEWzDIKh254XO+mM9XoXHk5GNEhodxeMznbg7BlRojVbKN+gC6g==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
+            "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -151,26 +152,26 @@
             }
         },
         "node_modules/@es-joy/jsdoccomment": {
-            "version": "0.52.0",
-            "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.52.0.tgz",
-            "integrity": "sha512-BXuN7BII+8AyNtn57euU2Yxo9yA/KUDNzrpXyi3pfqKmBhhysR6ZWOebFh3vyPoqA3/j1SOvGgucElMGwlXing==",
+            "version": "0.56.0",
+            "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.56.0.tgz",
+            "integrity": "sha512-c6EW+aA1w2rjqOMjbL93nZlwxp6c1Ln06vTYs5FjRRhmJXK8V/OrSXdT+pUr4aRYgjCgu8/OkiZr0tzeVrRSbw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/estree": "^1.0.8",
-                "@typescript-eslint/types": "^8.34.1",
+                "@typescript-eslint/types": "^8.42.0",
                 "comment-parser": "1.4.1",
                 "esquery": "^1.6.0",
-                "jsdoc-type-pratt-parser": "~4.1.0"
+                "jsdoc-type-pratt-parser": "~5.1.0"
             },
             "engines": {
                 "node": ">=20.11.0"
             }
         },
         "node_modules/@eslint-community/eslint-utils": {
-            "version": "4.7.0",
-            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.7.0.tgz",
-            "integrity": "sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==",
+            "version": "4.9.0",
+            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
+            "integrity": "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -225,9 +226,9 @@
             }
         },
         "node_modules/@eslint/config-helpers": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.3.0.tgz",
-            "integrity": "sha512-ViuymvFmcJi04qdZeDc2whTHryouGcDlaxPqarTD0ZE10ISpxGUVZGZDx4w01upyIynL3iu6IXH2bS1NhclQMw==",
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.3.1.tgz",
+            "integrity": "sha512-xR93k9WhrDYpXHORXpxVL5oHj3Era7wo6k/Wd8/IsQNnZUTzkGS29lyn3nAT05v6ltUuTFVCCYDEGfy2Or/sPA==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -235,9 +236,9 @@
             }
         },
         "node_modules/@eslint/core": {
-            "version": "0.15.1",
-            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.1.tgz",
-            "integrity": "sha512-bkOp+iumZCCbt1K1CmWf0R9pM5yKpDv+ZXtvSyQpudrI9kuFLp+bM2WOPXImuD/ceQuaa8f5pj93Y7zyECIGNA==",
+            "version": "0.15.2",
+            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.2.tgz",
+            "integrity": "sha512-78Md3/Rrxh83gCxoUc0EiciuOHsIITzLy53m3d9UyiW8y9Dj2D29FeETqyKA+BRK76tnTp6RXWb3pCay8Oyomg==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -309,9 +310,9 @@
             "license": "MIT"
         },
         "node_modules/@eslint/js": {
-            "version": "9.32.0",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.32.0.tgz",
-            "integrity": "sha512-BBpRFZK3eX6uMLKz8WxFOBIFFcGFJ/g8XuwjTHCqHROSIsopI+ddn/d5Cfh36+7+e5edVS8dbSHnBNhrLEX0zg==",
+            "version": "9.35.0",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.35.0.tgz",
+            "integrity": "sha512-30iXE9whjlILfWobBkNerJo+TXYsgVM5ERQwMcMKCHckHflCmf7wXDAHlARoWnh0s1U72WqlbeyE7iAcCzuCPw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -332,13 +333,13 @@
             }
         },
         "node_modules/@eslint/plugin-kit": {
-            "version": "0.3.4",
-            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.4.tgz",
-            "integrity": "sha512-Ul5l+lHEcw3L5+k8POx6r74mxEYKG5kOb6Xpy2gCRW6zweT6TEhAf8vhxGgjhqrd/VO/Dirhsb+1hNpD1ue9hw==",
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.5.tgz",
+            "integrity": "sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@eslint/core": "^0.15.1",
+                "@eslint/core": "^0.15.2",
                 "levn": "^0.4.1"
             },
             "engines": {
@@ -356,31 +357,17 @@
             }
         },
         "node_modules/@humanfs/node": {
-            "version": "0.16.6",
-            "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.6.tgz",
-            "integrity": "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==",
+            "version": "0.16.7",
+            "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
+            "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@humanfs/core": "^0.19.1",
-                "@humanwhocodes/retry": "^0.3.0"
+                "@humanwhocodes/retry": "^0.4.0"
             },
             "engines": {
                 "node": ">=18.18.0"
-            }
-        },
-        "node_modules/@humanfs/node/node_modules/@humanwhocodes/retry": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
-            "integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=18.18"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/nzakas"
             }
         },
         "node_modules/@humanwhocodes/module-importer": {
@@ -654,14 +641,14 @@
             }
         },
         "node_modules/@stylistic/eslint-plugin": {
-            "version": "5.2.2",
-            "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-5.2.2.tgz",
-            "integrity": "sha512-bE2DUjruqXlHYP3Q2Gpqiuj2bHq7/88FnuaS0FjeGGLCy+X6a07bGVuwtiOYnPSLHR6jmx5Bwdv+j7l8H+G97A==",
+            "version": "5.3.1",
+            "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-5.3.1.tgz",
+            "integrity": "sha512-Ykums1VYonM0TgkD0VteVq9mrlO2FhF48MDJnPyv3MktIB2ydtuhlO0AfWm7xnW1kyf5bjOqA6xc7JjviuVTxg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.7.0",
-                "@typescript-eslint/types": "^8.37.0",
+                "@typescript-eslint/types": "^8.41.0",
                 "eslint-visitor-keys": "^4.2.1",
                 "espree": "^10.4.0",
                 "estraverse": "^5.3.0",
@@ -674,17 +661,34 @@
                 "eslint": ">=9.0.0"
             }
         },
+        "node_modules/@trojs/error": {
+            "version": "4.3.6",
+            "resolved": "https://registry.npmjs.org/@trojs/error/-/error-4.3.6.tgz",
+            "integrity": "sha512-vo6R9iQjC0QE8apznnU5Y4Avlxn1jwJvgAVRL4HDffZ8ttby9r/TQcIcbdC3cKpvOBzWPsVaD6NC8rg5afjKyw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@trojs/validator": "^11.0.0"
+            },
+            "engines": {
+                "node": ">= 20"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/w3nl"
+            }
+        },
         "node_modules/@trojs/lint": {
-            "version": "0.3.6",
-            "resolved": "https://registry.npmjs.org/@trojs/lint/-/lint-0.3.6.tgz",
-            "integrity": "sha512-xPJI8fk54yPadkWZ2mhf6QxNvwJDuiH2cA5yTbfrFVz2om12kj5dRa9qG017oMR5Obd4foxTONu6CgFi25x1Ww==",
+            "version": "0.3.7",
+            "resolved": "https://registry.npmjs.org/@trojs/lint/-/lint-0.3.7.tgz",
+            "integrity": "sha512-yDSBhEWNhAEJSNfC9wrPheLYK0EcuL/kBpHEVvoK6V/9gHjxSAadggP7jfocK4TB6JMJpKAaHYVFALltmxrokA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@stylistic/eslint-plugin": "^5.0.0",
                 "eslint": "^9.19.0",
                 "eslint-plugin-import-x": "^4.6.1",
-                "eslint-plugin-jsdoc": "^52.0.0",
+                "eslint-plugin-jsdoc": "^54.0.0",
                 "eslint-plugin-n": "^17.15.1",
                 "eslint-plugin-promise": "^7.2.1",
                 "eslint-plugin-sonarjs": "^3.0.1",
@@ -698,10 +702,24 @@
                 "url": "https://github.com/sponsors/w3nl"
             }
         },
+        "node_modules/@trojs/validator": {
+            "version": "11.1.5",
+            "resolved": "https://registry.npmjs.org/@trojs/validator/-/validator-11.1.5.tgz",
+            "integrity": "sha512-CgXdtPOlhCJFTjP9M+WkCWO2my9i+Nyvr6OyuCZEW9OZaS2M9ko2TfjTkeEyt5GET6O6TynlDmenYqi7ZhylRA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 20"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/w3nl"
+            }
+        },
         "node_modules/@tybys/wasm-util": {
-            "version": "0.10.0",
-            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.0.tgz",
-            "integrity": "sha512-VyyPYFlOMNylG45GoAe0xDoLwWuowvf92F9kySqzYh8vmYm7D2u4iUJKa1tOUpS70Ku13ASrOkS4ScXFsTaCNQ==",
+            "version": "0.10.1",
+            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+            "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -743,9 +761,9 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "22.17.0",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.17.0.tgz",
-            "integrity": "sha512-bbAKTCqX5aNVryi7qXVMi+OkB3w/OyblodicMbvE38blyAz7GxXf6XYhklokijuPwwVg9sDLKRxt0ZHXQwZVfQ==",
+            "version": "22.18.1",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.1.tgz",
+            "integrity": "sha512-rzSDyhn4cYznVG+PCzGe1lwuMYJrcBS1fc3JqSa2PvtABwWo+dZ1ij5OVok3tqfpEBCBoaR4d7upFJk73HRJDw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -785,9 +803,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.38.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.38.0.tgz",
-            "integrity": "sha512-wzkUfX3plUqij4YwWaJyqhiPE5UCRVlFpKn1oCRn2O1bJ592XxWJj8ROQ3JD5MYXLORW84063z3tZTb/cs4Tyw==",
+            "version": "8.43.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.43.0.tgz",
+            "integrity": "sha512-vQ2FZaxJpydjSZJKiSW/LJsabFFvV7KgLC5DiLhkBcykhQj8iK9BOaDmQt74nnKdLvceM5xmhaTF+pLekrxEkw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1187,87 +1205,6 @@
             "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
             "license": "Python-2.0"
         },
-        "node_modules/array-buffer-byte-length": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
-            "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bound": "^1.0.3",
-                "is-array-buffer": "^3.0.5"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/array-includes": {
-            "version": "3.1.9",
-            "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.9.tgz",
-            "integrity": "sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bind": "^1.0.8",
-                "call-bound": "^1.0.4",
-                "define-properties": "^1.2.1",
-                "es-abstract": "^1.24.0",
-                "es-object-atoms": "^1.1.1",
-                "get-intrinsic": "^1.3.0",
-                "is-string": "^1.1.1",
-                "math-intrinsics": "^1.1.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/array.prototype.flat": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz",
-            "integrity": "sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bind": "^1.0.8",
-                "define-properties": "^1.2.1",
-                "es-abstract": "^1.23.5",
-                "es-shim-unscopables": "^1.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/arraybuffer.prototype.slice": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
-            "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "array-buffer-byte-length": "^1.0.1",
-                "call-bind": "^1.0.8",
-                "define-properties": "^1.2.1",
-                "es-abstract": "^1.23.5",
-                "es-errors": "^1.3.0",
-                "get-intrinsic": "^1.2.6",
-                "is-array-buffer": "^3.0.4"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/asap": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
@@ -1282,38 +1219,12 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/async-function": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
-            "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
         "node_modules/asynckit": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
             "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/available-typed-arrays": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
-            "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "possible-typed-array-names": "^1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
         },
         "node_modules/babel-walk": {
             "version": "3.0.0-canary-5",
@@ -1419,25 +1330,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
-            }
-        },
-        "node_modules/call-bind": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
-            "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bind-apply-helpers": "^1.0.0",
-                "es-define-property": "^1.0.0",
-                "get-intrinsic": "^1.2.4",
-                "set-function-length": "^1.2.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/call-bind-apply-helpers": {
@@ -1732,60 +1624,6 @@
                 "node": ">= 8"
             }
         },
-        "node_modules/data-view-buffer": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
-            "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bound": "^1.0.3",
-                "es-errors": "^1.3.0",
-                "is-data-view": "^1.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/data-view-byte-length": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
-            "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bound": "^1.0.3",
-                "es-errors": "^1.3.0",
-                "is-data-view": "^1.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/inspect-js"
-            }
-        },
-        "node_modules/data-view-byte-offset": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
-            "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bound": "^1.0.2",
-                "es-errors": "^1.3.0",
-                "is-data-view": "^1.0.1"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/debug": {
             "version": "4.4.1",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
@@ -1809,42 +1647,6 @@
             "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/define-data-property": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
-            "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "es-define-property": "^1.0.0",
-                "es-errors": "^1.3.0",
-                "gopd": "^1.0.1"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/define-properties": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
-            "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "define-data-property": "^1.0.1",
-                "has-property-descriptors": "^1.0.0",
-                "object-keys": "^1.1.1"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
         },
         "node_modules/delayed-stream": {
             "version": "1.0.0",
@@ -1936,9 +1738,9 @@
             }
         },
         "node_modules/enhanced-resolve": {
-            "version": "5.18.2",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.2.tgz",
-            "integrity": "sha512-6Jw4sE1maoRJo3q8MsSIn2onJFbLTOjY9hlx4DZXmOKvLRd1Ok2kXmAGXaafL2+ijsJZ1ClYbl/pmqr9+k4iUQ==",
+            "version": "5.18.3",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.3.tgz",
+            "integrity": "sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1947,75 +1749,6 @@
             },
             "engines": {
                 "node": ">=10.13.0"
-            }
-        },
-        "node_modules/es-abstract": {
-            "version": "1.24.0",
-            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.0.tgz",
-            "integrity": "sha512-WSzPgsdLtTcQwm4CROfS5ju2Wa1QQcVeT37jFjYzdFz1r9ahadC8B8/a4qxJxM+09F18iumCdRmlr96ZYkQvEg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "array-buffer-byte-length": "^1.0.2",
-                "arraybuffer.prototype.slice": "^1.0.4",
-                "available-typed-arrays": "^1.0.7",
-                "call-bind": "^1.0.8",
-                "call-bound": "^1.0.4",
-                "data-view-buffer": "^1.0.2",
-                "data-view-byte-length": "^1.0.2",
-                "data-view-byte-offset": "^1.0.1",
-                "es-define-property": "^1.0.1",
-                "es-errors": "^1.3.0",
-                "es-object-atoms": "^1.1.1",
-                "es-set-tostringtag": "^2.1.0",
-                "es-to-primitive": "^1.3.0",
-                "function.prototype.name": "^1.1.8",
-                "get-intrinsic": "^1.3.0",
-                "get-proto": "^1.0.1",
-                "get-symbol-description": "^1.1.0",
-                "globalthis": "^1.0.4",
-                "gopd": "^1.2.0",
-                "has-property-descriptors": "^1.0.2",
-                "has-proto": "^1.2.0",
-                "has-symbols": "^1.1.0",
-                "hasown": "^2.0.2",
-                "internal-slot": "^1.1.0",
-                "is-array-buffer": "^3.0.5",
-                "is-callable": "^1.2.7",
-                "is-data-view": "^1.0.2",
-                "is-negative-zero": "^2.0.3",
-                "is-regex": "^1.2.1",
-                "is-set": "^2.0.3",
-                "is-shared-array-buffer": "^1.0.4",
-                "is-string": "^1.1.1",
-                "is-typed-array": "^1.1.15",
-                "is-weakref": "^1.1.1",
-                "math-intrinsics": "^1.1.0",
-                "object-inspect": "^1.13.4",
-                "object-keys": "^1.1.1",
-                "object.assign": "^4.1.7",
-                "own-keys": "^1.0.1",
-                "regexp.prototype.flags": "^1.5.4",
-                "safe-array-concat": "^1.1.3",
-                "safe-push-apply": "^1.0.0",
-                "safe-regex-test": "^1.1.0",
-                "set-proto": "^1.0.0",
-                "stop-iteration-iterator": "^1.1.0",
-                "string.prototype.trim": "^1.2.10",
-                "string.prototype.trimend": "^1.0.9",
-                "string.prototype.trimstart": "^1.0.8",
-                "typed-array-buffer": "^1.0.3",
-                "typed-array-byte-length": "^1.0.3",
-                "typed-array-byte-offset": "^1.0.4",
-                "typed-array-length": "^1.0.7",
-                "unbox-primitive": "^1.1.0",
-                "which-typed-array": "^1.1.19"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/es-define-property": {
@@ -2064,37 +1797,6 @@
                 "node": ">= 0.4"
             }
         },
-        "node_modules/es-shim-unscopables": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz",
-            "integrity": "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "hasown": "^2.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/es-to-primitive": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
-            "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-callable": "^1.2.7",
-                "is-date-object": "^1.0.5",
-                "is-symbol": "^1.0.4"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/escape-html": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -2115,20 +1817,20 @@
             }
         },
         "node_modules/eslint": {
-            "version": "9.32.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.32.0.tgz",
-            "integrity": "sha512-LSehfdpgMeWcTZkWZVIJl+tkZ2nuSkyyB9C27MZqFWXuph7DvaowgcTvKqxvpLW1JZIk8PN7hFY3Rj9LQ7m7lg==",
+            "version": "9.35.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.35.0.tgz",
+            "integrity": "sha512-QePbBFMJFjgmlE+cXAlbHZbHpdFVS2E/6vzCy7aKlebddvl1vadiC4JFV5u/wqTkNUwEV8WrQi257jf5f06hrg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@eslint-community/eslint-utils": "^4.2.0",
+                "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.1",
                 "@eslint/config-array": "^0.21.0",
-                "@eslint/config-helpers": "^0.3.0",
-                "@eslint/core": "^0.15.0",
+                "@eslint/config-helpers": "^0.3.1",
+                "@eslint/core": "^0.15.2",
                 "@eslint/eslintrc": "^3.3.1",
-                "@eslint/js": "9.32.0",
-                "@eslint/plugin-kit": "^0.3.4",
+                "@eslint/js": "9.35.0",
+                "@eslint/plugin-kit": "^0.3.5",
                 "@humanfs/node": "^0.16.6",
                 "@humanwhocodes/module-importer": "^1.0.1",
                 "@humanwhocodes/retry": "^0.4.2",
@@ -2292,13 +1994,13 @@
             }
         },
         "node_modules/eslint-plugin-jsdoc": {
-            "version": "52.0.1",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-52.0.1.tgz",
-            "integrity": "sha512-zJdjpC9z4x28BBdCoxH+/h0BdDLZ9KXQGVKU9gHt3TQJ9kMraep+DgfTIVaXu9u1wy0HyhK2eFMp3icQBV4dkw==",
+            "version": "54.7.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-54.7.0.tgz",
+            "integrity": "sha512-u5Na4he2+6kY1rWqxzbQaAwJL3/tDCuT5ElDRc5UJ9stOeQeQ5L1JJ1kRRu7ldYMlOHMCJLsY8Mg/Tu3ExdZiQ==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
-                "@es-joy/jsdoccomment": "~0.52.0",
+                "@es-joy/jsdoccomment": "~0.56.0",
                 "are-docs-informative": "^0.0.2",
                 "comment-parser": "1.4.1",
                 "debug": "^4.4.1",
@@ -2376,9 +2078,9 @@
             }
         },
         "node_modules/eslint-plugin-sonarjs": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-sonarjs/-/eslint-plugin-sonarjs-3.0.4.tgz",
-            "integrity": "sha512-ftQcP811kRJNXapqpQXHErEoVOdTPfYPPYd7n3AExIPwv4qWKKHf4slFvXmodiOnfgy1Tl3waPZZLD7lcvJOtw==",
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-sonarjs/-/eslint-plugin-sonarjs-3.0.5.tgz",
+            "integrity": "sha512-dI62Ff3zMezUToi161hs2i1HX1ie8Ia2hO0jtNBfdgRBicAG4ydy2WPt0rMTrAe3ZrlqhpAO3w1jcQEdneYoFA==",
             "dev": true,
             "license": "LGPL-3.0-only",
             "dependencies": {
@@ -2386,7 +2088,7 @@
                 "builtin-modules": "3.3.0",
                 "bytes": "3.1.2",
                 "functional-red-black-tree": "1.0.1",
-                "jsx-ast-utils": "3.3.5",
+                "jsx-ast-utils-x": "0.1.0",
                 "lodash.merge": "4.6.2",
                 "minimatch": "9.0.5",
                 "scslre": "0.3.0",
@@ -2681,9 +2383,9 @@
             "license": "MIT"
         },
         "node_modules/fast-uri": {
-            "version": "3.0.6",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
-            "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+            "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
             "funding": [
                 {
                     "type": "github",
@@ -2787,22 +2489,6 @@
             "dev": true,
             "license": "ISC"
         },
-        "node_modules/for-each": {
-            "version": "0.3.5",
-            "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
-            "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-callable": "^1.2.7"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/form-data": {
             "version": "4.0.4",
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
@@ -2880,9 +2566,9 @@
             }
         },
         "node_modules/fs-extra": {
-            "version": "11.3.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
-            "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
+            "version": "11.3.1",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.1.tgz",
+            "integrity": "sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2903,43 +2589,12 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/function.prototype.name": {
-            "version": "1.1.8",
-            "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
-            "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bind": "^1.0.8",
-                "call-bound": "^1.0.3",
-                "define-properties": "^1.2.1",
-                "functions-have-names": "^1.2.3",
-                "hasown": "^2.0.2",
-                "is-callable": "^1.2.7"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/functional-red-black-tree": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
             "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/functions-have-names": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
-            "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
-            "dev": true,
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
         },
         "node_modules/get-intrinsic": {
             "version": "1.3.0",
@@ -2994,24 +2649,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/get-symbol-description": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
-            "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bound": "^1.0.3",
-                "es-errors": "^1.3.0",
-                "get-intrinsic": "^1.2.6"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/get-tsconfig": {
             "version": "4.10.1",
             "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.1.tgz",
@@ -3049,9 +2686,9 @@
             }
         },
         "node_modules/globals": {
-            "version": "16.3.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-16.3.0.tgz",
-            "integrity": "sha512-bqWEnJ1Nt3neqx2q5SFfGS8r/ahumIakg3HcwtNlrVlwXIeNumWn/c7Pn/wKzGhf6SaW6H6uWXLqC30STCMchQ==",
+            "version": "16.4.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-16.4.0.tgz",
+            "integrity": "sha512-ob/2LcVVaVGCYN+r14cnwnoDPUufjiYgSqRhiFD0Q1iI4Odora5RE8Iv1D24hAz5oMophRGkGz+yuvQmmUMnMw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3059,23 +2696,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/globalthis": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
-            "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "define-properties": "^1.2.1",
-                "gopd": "^1.0.1"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/globrex": {
@@ -3104,19 +2724,6 @@
             "dev": true,
             "license": "ISC"
         },
-        "node_modules/has-bigints": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
-            "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/has-flag": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -3125,35 +2732,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/has-property-descriptors": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
-            "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "es-define-property": "^1.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/has-proto": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
-            "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "dunder-proto": "^1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/has-symbols": {
@@ -3301,21 +2879,6 @@
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
             "license": "ISC"
         },
-        "node_modules/internal-slot": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
-            "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "es-errors": "^1.3.0",
-                "hasown": "^2.0.2",
-                "side-channel": "^1.1.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
         "node_modules/ipaddr.js": {
             "version": "1.9.1",
             "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -3323,90 +2886,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.10"
-            }
-        },
-        "node_modules/is-array-buffer": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
-            "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bind": "^1.0.8",
-                "call-bound": "^1.0.3",
-                "get-intrinsic": "^1.2.6"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-async-function": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
-            "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "async-function": "^1.0.0",
-                "call-bound": "^1.0.3",
-                "get-proto": "^1.0.1",
-                "has-tostringtag": "^1.0.2",
-                "safe-regex-test": "^1.1.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-bigint": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
-            "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "has-bigints": "^1.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-boolean-object": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
-            "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bound": "^1.0.3",
-                "has-tostringtag": "^1.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-callable": {
-            "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
-            "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/is-core-module": {
@@ -3417,41 +2896,6 @@
             "license": "MIT",
             "dependencies": {
                 "hasown": "^2.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-data-view": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
-            "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bound": "^1.0.2",
-                "get-intrinsic": "^1.2.6",
-                "is-typed-array": "^1.1.13"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-date-object": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
-            "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bound": "^1.0.2",
-                "has-tostringtag": "^1.0.2"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -3494,22 +2938,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/is-finalizationregistry": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
-            "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bound": "^1.0.3"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/is-fullwidth-code-point": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -3518,25 +2946,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/is-generator-function": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.0.tgz",
-            "integrity": "sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bound": "^1.0.3",
-                "get-proto": "^1.0.0",
-                "has-tostringtag": "^1.0.2",
-                "safe-regex-test": "^1.1.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/is-glob": {
@@ -3552,32 +2961,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/is-map": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
-            "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-negative-zero": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
-            "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/is-number": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -3586,23 +2969,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.12.0"
-            }
-        },
-        "node_modules/is-number-object": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
-            "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bound": "^1.0.3",
-                "has-tostringtag": "^1.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/is-promise": {
@@ -3631,35 +2997,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/is-set": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
-            "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-shared-array-buffer": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
-            "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bound": "^1.0.3"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/is-stream": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -3672,110 +3009,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
-        },
-        "node_modules/is-string": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
-            "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bound": "^1.0.3",
-                "has-tostringtag": "^1.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-symbol": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
-            "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bound": "^1.0.2",
-                "has-symbols": "^1.1.0",
-                "safe-regex-test": "^1.1.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-typed-array": {
-            "version": "1.1.15",
-            "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
-            "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "which-typed-array": "^1.1.16"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-weakmap": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
-            "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-weakref": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
-            "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bound": "^1.0.3"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-weakset": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
-            "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bound": "^1.0.3",
-                "get-intrinsic": "^1.2.6"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/isarray": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-            "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/isexe": {
             "version": "2.0.0",
@@ -3837,9 +3070,9 @@
             }
         },
         "node_modules/jsdoc-type-pratt-parser": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.1.0.tgz",
-            "integrity": "sha512-Hicd6JK5Njt2QB6XYFS7ok9e37O8AYk3jTcppG4YVQnYjOemymvTcmc7OWsmq/Qqj5TdRFO5/x/tIPmBeRtGHg==",
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-5.1.1.tgz",
+            "integrity": "sha512-DYYlVP1fe4QBMh2xTIs20/YeTz2GYVbWAEZweHSZD+qQ/Cx2d5RShuhhsdk64eTjNq0FeVnteP/qVOgaywSRbg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3867,9 +3100,9 @@
             "license": "MIT"
         },
         "node_modules/jsonfile": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+            "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3890,20 +3123,14 @@
                 "promise": "^7.0.1"
             }
         },
-        "node_modules/jsx-ast-utils": {
-            "version": "3.3.5",
-            "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
-            "integrity": "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==",
+        "node_modules/jsx-ast-utils-x": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/jsx-ast-utils-x/-/jsx-ast-utils-x-0.1.0.tgz",
+            "integrity": "sha512-eQQBjBnsVtGacsG9uJNB8qOr3yA8rga4wAaGG1qRcBzSIvfhERLrWxMAM1hp5fcS6Abo8M4+bUBTekYR0qTPQw==",
             "dev": true,
             "license": "MIT",
-            "dependencies": {
-                "array-includes": "^3.1.6",
-                "array.prototype.flat": "^1.3.1",
-                "object.assign": "^4.1.4",
-                "object.values": "^1.1.6"
-            },
             "engines": {
-                "node": ">=4.0"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             }
         },
         "node_modules/keyv": {
@@ -4147,9 +3374,9 @@
             "license": "MIT"
         },
         "node_modules/napi-postinstall": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.2.tgz",
-            "integrity": "sha512-tWVJxJHmBWLy69PvO96TZMZDrzmw5KeiZBz3RHmiM2XZ9grBJ2WgMAFVVg25nqp3ZjTFUs2Ftw1JhscL3Teliw==",
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.3.tgz",
+            "integrity": "sha512-uTp172LLXSxuSYHv/kou+f6KW3SMppU9ivthaVTXian9sOt3XM/zHYHpRZiLgQoxeWfYUnslNWQHF1+G71xcow==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -4241,56 +3468,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/object-keys": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-            "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/object.assign": {
-            "version": "4.1.7",
-            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
-            "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bind": "^1.0.8",
-                "call-bound": "^1.0.3",
-                "define-properties": "^1.2.1",
-                "es-object-atoms": "^1.0.0",
-                "has-symbols": "^1.1.0",
-                "object-keys": "^1.1.1"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/object.values": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.1.tgz",
-            "integrity": "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bind": "^1.0.8",
-                "call-bound": "^1.0.3",
-                "define-properties": "^1.2.1",
-                "es-object-atoms": "^1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/on-finished": {
             "version": "2.4.1",
             "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -4338,9 +3515,9 @@
             }
         },
         "node_modules/openapi-backend": {
-            "version": "5.13.0",
-            "resolved": "https://registry.npmjs.org/openapi-backend/-/openapi-backend-5.13.0.tgz",
-            "integrity": "sha512-dE2f0MCpL2ZKctVG4w+Nl+1C4GQput5dQ4QYy6XeblGvM2Z1b3JcP2FzL6DrLzzDYEKTLgAaQM3jD7yhftwKSg==",
+            "version": "5.15.0",
+            "resolved": "https://registry.npmjs.org/openapi-backend/-/openapi-backend-5.15.0.tgz",
+            "integrity": "sha512-yox0nCv511YWUeBNCdKY6xmUB92yEN+N9rHO4BHA5GOAZaNtY+zzuftAdfEwIbCsCcvZJ9ysENCguqBg+hLlWw==",
             "license": "MIT",
             "dependencies": {
                 "@apidevtools/json-schema-ref-parser": "^11.1.0",
@@ -4421,24 +3598,6 @@
             },
             "engines": {
                 "node": ">= 0.8.0"
-            }
-        },
-        "node_modules/own-keys": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
-            "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "get-intrinsic": "^1.2.6",
-                "object-keys": "^1.1.1",
-                "safe-push-apply": "^1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/p-limit": {
@@ -4540,12 +3699,13 @@
             "license": "MIT"
         },
         "node_modules/path-to-regexp": {
-            "version": "8.2.0",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
-            "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
+            "version": "8.3.0",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+            "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
             "license": "MIT",
-            "engines": {
-                "node": ">=16"
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/picomatch": {
@@ -4559,16 +3719,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/jonschlinkert"
-            }
-        },
-        "node_modules/possible-typed-array-names": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
-            "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
             }
         },
         "node_modules/prelude-ls": {
@@ -4823,18 +3973,34 @@
             }
         },
         "node_modules/raw-body": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
-            "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.1.tgz",
+            "integrity": "sha512-9G8cA+tuMS75+6G/TzW8OtLzmBDMo8p1JRxN5AZ+LAp8uxGA8V8GZm4GQ4/N5QNQEnLmg6SS7wyuSmbKepiKqA==",
             "license": "MIT",
             "dependencies": {
                 "bytes": "3.1.2",
                 "http-errors": "2.0.0",
-                "iconv-lite": "0.6.3",
+                "iconv-lite": "0.7.0",
                 "unpipe": "1.0.0"
             },
             "engines": {
-                "node": ">= 0.8"
+                "node": ">= 0.10"
+            }
+        },
+        "node_modules/raw-body/node_modules/iconv-lite": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
+            "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
+            "license": "MIT",
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/refa": {
@@ -4850,29 +4016,6 @@
                 "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
             }
         },
-        "node_modules/reflect.getprototypeof": {
-            "version": "1.0.10",
-            "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
-            "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bind": "^1.0.8",
-                "define-properties": "^1.2.1",
-                "es-abstract": "^1.23.9",
-                "es-errors": "^1.3.0",
-                "es-object-atoms": "^1.0.0",
-                "get-intrinsic": "^1.2.7",
-                "get-proto": "^1.0.1",
-                "which-builtin-type": "^1.2.1"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/regexp-ast-analysis": {
             "version": "0.7.1",
             "resolved": "https://registry.npmjs.org/regexp-ast-analysis/-/regexp-ast-analysis-0.7.1.tgz",
@@ -4885,27 +4028,6 @@
             },
             "engines": {
                 "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
-            }
-        },
-        "node_modules/regexp.prototype.flags": {
-            "version": "1.5.4",
-            "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
-            "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bind": "^1.0.8",
-                "define-properties": "^1.2.1",
-                "es-errors": "^1.3.0",
-                "get-proto": "^1.0.1",
-                "gopd": "^1.2.0",
-                "set-function-name": "^2.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/repeat-string": {
@@ -5032,26 +4154,6 @@
                 "queue-microtask": "^1.2.2"
             }
         },
-        "node_modules/safe-array-concat": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
-            "integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bind": "^1.0.8",
-                "call-bound": "^1.0.2",
-                "get-intrinsic": "^1.2.6",
-                "has-symbols": "^1.1.0",
-                "isarray": "^2.0.5"
-            },
-            "engines": {
-                "node": ">=0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/safe-buffer": {
             "version": "5.2.1",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -5071,41 +4173,6 @@
                 }
             ],
             "license": "MIT"
-        },
-        "node_modules/safe-push-apply": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
-            "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "es-errors": "^1.3.0",
-                "isarray": "^2.0.5"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/safe-regex-test": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
-            "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bound": "^1.0.2",
-                "es-errors": "^1.3.0",
-                "is-regex": "^1.2.1"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
         },
         "node_modules/safer-buffer": {
             "version": "2.1.2",
@@ -5176,55 +4243,6 @@
             },
             "engines": {
                 "node": ">= 18"
-            }
-        },
-        "node_modules/set-function-length": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
-            "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "define-data-property": "^1.1.4",
-                "es-errors": "^1.3.0",
-                "function-bind": "^1.1.2",
-                "get-intrinsic": "^1.2.4",
-                "gopd": "^1.0.1",
-                "has-property-descriptors": "^1.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/set-function-name": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
-            "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "define-data-property": "^1.1.4",
-                "es-errors": "^1.3.0",
-                "functions-have-names": "^1.2.3",
-                "has-property-descriptors": "^1.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/set-proto": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
-            "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "dunder-proto": "^1.0.1",
-                "es-errors": "^1.3.0",
-                "es-object-atoms": "^1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
             }
         },
         "node_modules/setprototypeof": {
@@ -5361,9 +4379,9 @@
             }
         },
         "node_modules/spdx-license-ids": {
-            "version": "3.0.21",
-            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.21.tgz",
-            "integrity": "sha512-Bvg/8F5XephndSK3JffaRqdT+gyhfqIPwDHpX80tJrF8QQRYMo8sNMeaZ2Dp5+jhwKnUmIOyFFQfHRkjJm5nXg==",
+            "version": "3.0.22",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.22.tgz",
+            "integrity": "sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ==",
             "dev": true,
             "license": "CC0-1.0"
         },
@@ -5386,20 +4404,6 @@
                 "node": ">= 0.8"
             }
         },
-        "node_modules/stop-iteration-iterator": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
-            "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "es-errors": "^1.3.0",
-                "internal-slot": "^1.1.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
         "node_modules/string-width": {
             "version": "4.2.3",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -5413,65 +4417,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/string.prototype.trim": {
-            "version": "1.2.10",
-            "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
-            "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bind": "^1.0.8",
-                "call-bound": "^1.0.2",
-                "define-data-property": "^1.1.4",
-                "define-properties": "^1.2.1",
-                "es-abstract": "^1.23.5",
-                "es-object-atoms": "^1.0.0",
-                "has-property-descriptors": "^1.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/string.prototype.trimend": {
-            "version": "1.0.9",
-            "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
-            "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bind": "^1.0.8",
-                "call-bound": "^1.0.2",
-                "define-properties": "^1.2.1",
-                "es-object-atoms": "^1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/string.prototype.trimstart": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
-            "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bind": "^1.0.7",
-                "define-properties": "^1.2.1",
-                "es-object-atoms": "^1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/strip-ansi": {
@@ -5572,9 +4517,9 @@
             }
         },
         "node_modules/swagger-ui-dist": {
-            "version": "5.27.0",
-            "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.27.0.tgz",
-            "integrity": "sha512-tS6LRyBhY6yAqxrfsA9IYpGWPUJOri6sclySa7TdC7XQfGLvTwDY531KLgfQwHEtQsn+sT4JlUspbeQDBVGWig==",
+            "version": "5.29.0",
+            "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.29.0.tgz",
+            "integrity": "sha512-gqs7Md3AxP4mbpXAq31o5QW+wGUZsUzVatg70yXpUR245dfIis5jAzufBd+UQM/w2xSfrhvA1eqsrgnl2PbezQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@scarf/scarf": "=1.4.0"
@@ -5596,13 +4541,17 @@
             }
         },
         "node_modules/tapable": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.2.tgz",
-            "integrity": "sha512-Re10+NauLTMCudc7T5WLFLAwDhQ0JWdrMK+9B2M8zR5hRExKmsRDCBA7/aV/pNJFltmBFO5BAMlQFi/vq3nKOg==",
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.3.tgz",
+            "integrity": "sha512-ZL6DDuAlRlLGghwcfmSn9sK3Hr6ArtyudlSAiCqQ6IfE+b+HHbydbYDIG15IfS5do+7XQQBdBiubF/cV2dnDzg==",
             "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
             }
         },
         "node_modules/to-regex-range": {
@@ -5692,88 +4641,10 @@
                 "node": ">= 0.6"
             }
         },
-        "node_modules/typed-array-buffer": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
-            "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bound": "^1.0.3",
-                "es-errors": "^1.3.0",
-                "is-typed-array": "^1.1.14"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/typed-array-byte-length": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
-            "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bind": "^1.0.8",
-                "for-each": "^0.3.3",
-                "gopd": "^1.2.0",
-                "has-proto": "^1.2.0",
-                "is-typed-array": "^1.1.14"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/typed-array-byte-offset": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
-            "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "available-typed-arrays": "^1.0.7",
-                "call-bind": "^1.0.8",
-                "for-each": "^0.3.3",
-                "gopd": "^1.2.0",
-                "has-proto": "^1.2.0",
-                "is-typed-array": "^1.1.15",
-                "reflect.getprototypeof": "^1.0.9"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/typed-array-length": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
-            "integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bind": "^1.0.7",
-                "for-each": "^0.3.3",
-                "gopd": "^1.0.1",
-                "is-typed-array": "^1.1.13",
-                "possible-typed-array-names": "^1.0.0",
-                "reflect.getprototypeof": "^1.0.6"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/typescript": {
-            "version": "5.8.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-            "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+            "version": "5.9.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+            "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
@@ -5782,25 +4653,6 @@
             },
             "engines": {
                 "node": ">=14.17"
-            }
-        },
-        "node_modules/unbox-primitive": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
-            "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bound": "^1.0.3",
-                "has-bigints": "^1.0.2",
-                "has-symbols": "^1.1.0",
-                "which-boxed-primitive": "^1.1.1"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/undici-types": {
@@ -5907,95 +4759,6 @@
             },
             "engines": {
                 "node": ">= 8"
-            }
-        },
-        "node_modules/which-boxed-primitive": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
-            "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-bigint": "^1.1.0",
-                "is-boolean-object": "^1.2.1",
-                "is-number-object": "^1.1.1",
-                "is-string": "^1.1.1",
-                "is-symbol": "^1.1.1"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/which-builtin-type": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
-            "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bound": "^1.0.2",
-                "function.prototype.name": "^1.1.6",
-                "has-tostringtag": "^1.0.2",
-                "is-async-function": "^2.0.0",
-                "is-date-object": "^1.1.0",
-                "is-finalizationregistry": "^1.1.0",
-                "is-generator-function": "^1.0.10",
-                "is-regex": "^1.2.1",
-                "is-weakref": "^1.0.2",
-                "isarray": "^2.0.5",
-                "which-boxed-primitive": "^1.1.0",
-                "which-collection": "^1.0.2",
-                "which-typed-array": "^1.1.16"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/which-collection": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
-            "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-map": "^2.0.3",
-                "is-set": "^2.0.3",
-                "is-weakmap": "^2.0.2",
-                "is-weakset": "^2.0.3"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/which-typed-array": {
-            "version": "1.1.19",
-            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
-            "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "available-typed-arrays": "^1.0.7",
-                "call-bind": "^1.0.8",
-                "call-bound": "^1.0.4",
-                "for-each": "^0.3.5",
-                "get-proto": "^1.0.1",
-                "gopd": "^1.2.0",
-                "has-tostringtag": "^1.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/with": {

--- a/package.json
+++ b/package.json
@@ -35,9 +35,10 @@
     "main": "src/server.js",
     "devDependencies": {
         "@eslint/js": "^9.15.0",
+        "@trojs/error": "^4.3.6",
         "@trojs/lint": "^0.3.4",
-        "@types/node": "^22.0.0",
         "@types/express-serve-static-core": "^5.0.6",
+        "@types/node": "^22.0.0",
         "eslint": "^9.15.0",
         "globals": "^16.0.0",
         "jscpd": "^4.0.5",

--- a/src/error-status.js
+++ b/src/error-status.js
@@ -1,3 +1,7 @@
+/**
+ * @typedef {Error & { status?: number }} StatusError
+ */
+
 const errorCodesStatus = [
   {
     type: TypeError,
@@ -16,9 +20,10 @@ const errorCodesStatus = [
 /**
  * Get a http status when you send an error.
  * When it is a error, throw back the error.
- * @param {Error} error
+ * @param {StatusError} error
  * @returns {number}
  */
 export default (error) =>
-  errorCodesStatus.find((errorCode) => error instanceof errorCode.type)
-    .status
+  error.status
+  || errorCodesStatus.find((errorCode) => error instanceof errorCode.type)?.status
+  || 500

--- a/src/error-status.test.js
+++ b/src/error-status.test.js
@@ -1,5 +1,6 @@
 import test from 'node:test'
 import assert from 'node:assert'
+import { ValidationError } from '@trojs/error'
 import getStatusByError from './error-status.js'
 
 const TestCases = [
@@ -17,6 +18,21 @@ const TestCases = [
     description: 'A range error should return status 404',
     error: new RangeError('test'),
     expectedResult: 404
+  },
+  {
+    description: 'A validation error should return status 400',
+    error: new ValidationError({ message: 'test' }),
+    expectedResult: 400
+  },
+  {
+    description: 'A syntax error should return status 500',
+    error: new SyntaxError('test'),
+    expectedResult: 500
+  },
+  {
+    description: 'An unknown non-error object should return fallback status 500',
+    error: { foo: 'bar', message: 'test' },
+    expectedResult: 500
   }
 ]
 

--- a/src/express-callback.js
+++ b/src/express-callback.js
@@ -23,7 +23,7 @@ import { parseParams } from './params.js'
  * @returns {Function}
  */
 export const makeExpressCallback
-    = ({ controller, specification, errorDetails, logger, meta, mock, preLog, postLog }) =>
+  = ({ controller, specification, errorDetails, logger, meta, mock, preLog, postLog }) =>
     /**
      * Handle controller
      * @async
@@ -32,76 +32,76 @@ export const makeExpressCallback
      * @param {Response} response
      * @returns {Promise<any>}
      */
-      async (context, request, response) => {
-        const startTime = hrtime()
-        try {
-          const allParameters = {
-            ...(context.request?.params || {}),
-            ...(context.request?.query || {})
-          }
-          const parameters = parseParams({
-            query: allParameters,
-            spec: context.operation.parameters,
-            mock
-          })
-          const url = `${request.protocol}://${request.get('Host')}${request.originalUrl}`
-          const feedback = {
-            context,
-            request,
-            response,
-            parameters,
-            specification,
-            post: request.body,
-            url,
-            logger,
-            meta
-          }
-          if (preLog) {
-            preLog(feedback)
-          }
-          const responseBody = await controller(feedback)
-          const responseTime = hrtime(startTime)[1] / 1000000 // convert to milliseconds
-          if (postLog) {
-            postLog({ ...feedback, responseBody, responseTime })
-          }
-          logger.debug({
-            url,
-            parameters,
-            post: request.body,
-            response: responseBody
-          })
+    async (context, request, response) => {
+      const startTime = hrtime()
+      try {
+        const allParameters = {
+          ...(context.request?.params || {}),
+          ...(context.request?.query || {})
+        }
+        const parameters = parseParams({
+          query: allParameters,
+          spec: context.operation.parameters,
+          mock
+        })
+        const url = `${request.protocol}://${request.get('Host')}${request.originalUrl}`
+        const feedback = {
+          context,
+          request,
+          response,
+          parameters,
+          specification,
+          post: request.body,
+          url,
+          logger,
+          meta
+        }
+        if (preLog) {
+          preLog(feedback)
+        }
+        const responseBody = await controller(feedback)
+        const responseTime = hrtime(startTime)[1] / 1000000 // convert to milliseconds
+        if (postLog) {
+          postLog({ ...feedback, responseBody, responseTime })
+        }
+        logger.debug({
+          url,
+          parameters,
+          post: request.body,
+          response: responseBody
+        })
 
-          return responseBody
-        } catch (error) {
-          const errorCodeStatus = getStatusByError(error)
+        return responseBody
+      } catch (error) {
+        const errorCodeStatus = getStatusByError(error)
 
-          if (errorCodeStatus >= 500) {
-            logger.error(error)
-          } else {
-            logger.warn(error)
-          }
+        if (errorCodeStatus >= 500) {
+          logger.error(error)
+        } else {
+          logger.warn(error)
+        }
 
-          response.status(errorCodeStatus)
+        response.status(errorCodeStatus)
 
-          if (errorDetails) {
-            return {
-              errors: [
-                {
-                  message: error.message,
-                  value: error.valueOf(),
-                  type: error.constructor.name
-                }
-              ],
-              status: errorCodeStatus,
-              timestamp: new Date(),
-              message: error.message
-            }
-          }
-
+        if (errorDetails) {
           return {
+            errors: [
+              {
+                message: error.message,
+                value: error.valueOf(),
+                type: error.constructor.name
+              }
+            ],
             status: errorCodeStatus,
             timestamp: new Date(),
             message: error.message
           }
         }
+
+        return {
+          status: errorCodeStatus,
+          timestamp: new Date(),
+          message: error.message
+        }
       }
+    }

--- a/src/router.js
+++ b/src/router.js
@@ -92,7 +92,7 @@ export const setupRouter = ({
 
   api.register('notImplemented', (context) => {
     const { mock: mockImplementation }
-            = context.api.mockResponseForOperation(context.operation.operationId)
+      = context.api.mockResponseForOperation(context.operation.operationId)
     return mockImplementation
   })
 


### PR DESCRIPTION
See e.g. https://github.com/trojs/error/blob/main/src/validation-error.js that has the status 400.
If you throw this error, it will return a http status 400.

With this feature you are more flexible to work with any custom error with a status.
Not depending on something else like @trojs/error, the error only needs a status attribute, or else it falls back to the existing statuses for native error objects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - More accurate HTTP status mapping for errors (e.g., validation errors return 400; unknown errors default to 500).
- Bug Fixes
  - Consistent fallback error responses when detailed errors are disabled, returning status, timestamp, and message.
- Tests
  - Expanded test coverage for error-to-status mapping, including validation and syntax errors.
- Style
  - Minor formatting/indentation adjustments with no functional impact.
- Chores
  - Added a development dependency to support error handling improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->